### PR TITLE
add alternative super tier cooldowns for specific subclasses

### DIFF
--- a/src/app/component/profile/controller.js
+++ b/src/app/component/profile/controller.js
@@ -99,17 +99,33 @@ app.controller('profileCtrl', [
                 }
             };
 
-            $scope.getSuperCooldown = function(stat) {
-                var tiers = {
-                    0: '5:30',
-                    1: '5:14',
-                    2: '4:57',
-                    3: '4:39',
-                    4: '4:20',
-                    5: '3:40'
-                };
-
-                return tiers[$scope.statToTier(stat)];
+            $scope.getSuperCooldown = function(stat, items) {
+                var tiers = {};
+                var subClass = _.find(items, function(i) {
+                    return i.bucketHash == consts.buckets['subclass'];
+                });
+                if (subClass) {
+                    if ([3658182170,2007186000,2455559914,4143670657].indexOf(subClass.items[0].itemHash) > -1 ) {
+                        tiers = {
+                            0: '5:00',
+                            1: '4:46',
+                            2: '4:31',
+                            3: '4:15',
+                            4: '3:58',
+                            5: '3:40'
+                        };
+                    } else {
+                        tiers = {
+                            0: '5:30',
+                            1: '5:14',
+                            2: '4:57',
+                            3: '4:39',
+                            4: '4:20',
+                            5: '4:00'
+                        };
+                    }
+                    return tiers[$scope.statToTier(stat)];
+                }
             };
 
             $scope.getUtilityCooldown = function(stat) {

--- a/src/view/profile/_character.html
+++ b/src/view/profile/_character.html
@@ -49,7 +49,7 @@
 
     <div class="stat col-xs-3">
         <h4><i class="ggg ggg-intellect"></i> T{{statToTier(character.characterBase.stats.STAT_INTELLECT.value)}}</h4>
-        <span><strong class="value">{{getSuperCooldown(character.characterBase.stats.STAT_INTELLECT.value)}}</strong> <translate>Super</translate></span>
+        <span><strong class="value">{{getSuperCooldown(character.characterBase.stats.STAT_INTELLECT.value, items)}}</strong> <translate>Super</translate></span>
     </div>
 
     <div class="stat col-xs-3">


### PR DESCRIPTION
defender, nightstalker, striker and sunsingers have lower cooldowns than the rest of the subclasses.

feel free to use the data to implement your own fix since dont like having to iterate through items again to get the subclass hash.
