### PR TITLE
Disabled autocorrect, autocomplete, and spellcheck

### DIFF
--- a/src/app/component/layout/main.html
+++ b/src/app/component/layout/main.html
@@ -18,7 +18,7 @@
         <div class="clear"></div>
         <form ng-submit="searchForPlayer(name)" class="search">
             <div class="input-group">
-                <input type="text" class="form-control" ng-model="name" placeholder="{{ placeholder }}">
+                <input type="text" class="form-control" ng-model="name" placeholder="{{ placeholder }}" autocorrect="off" autocomplete="off" spellcheck="false">
                     <span class="input-group-btn">
                         <button class="btn btn-default fa fa-search" type="submit"></button>
                     </span>


### PR DESCRIPTION
Turn off autocorrect/autocomplete/spellcheck because it is an issue while using the site on mobile devices. Too many times names get changed due to the device's autocorrect/autocomplete features.
