### PR TITLE
Don't restrict to 6 game modes on the profile page

### DIFF
--- a/src/app/component/profile/activity-history.html
+++ b/src/app/component/profile/activity-history.html
@@ -34,7 +34,7 @@
 </div>
 <div class="elo">
     <div class="ratings row" ng-if="elos.length > 0 && !loading.elo">
-        <div ng-repeat="e in ::elos" class="col-xs-2 rating clickable" ng-style="{ 'background-color': e.league.colors.background }" ng-if="$index < 6" ng-click="setMode(e.mode)">
+        <div ng-repeat="e in ::elos" class="col-xs-2 rating clickable" ng-style="{ 'background-color': e.league.colors.background }" ng-click="setMode(e.mode)">
             <i class="ggg {{modeIcons[e.mode]}}"></i>
             <span ng-if="e.rank != -1">{{ e.elo|number:0 }}</span>
             <span ng-if="e.rank == -1">N/A</span>


### PR DESCRIPTION
The page doesn't look that bad when the game modes wrap, and it is frustrating to not be able to select the modes you'd like to show (e.g. I don't care about my clash Elo, but I do care about trials, etc). I think adding some UI to select which modes show just adds complication, so it'd probably be best/easiest just to remove the limit.
